### PR TITLE
Loosen cumber-gherkin version constraint

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "cucumber-gherkin", "~> 18.0"
+  s.add_runtime_dependency "cucumber-gherkin"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
In attempt to upgrade cucumber to version 5 when used with cucumber-rails